### PR TITLE
Menu: open className and aria-expanded on li, initially set aria-expanded="false"

### DIFF
--- a/a11yfy/jquery.a11yfy.core.css
+++ b/a11yfy/jquery.a11yfy.core.css
@@ -90,7 +90,7 @@
 }
 
 .a11yfy-top-level-menu li:hover > ul,
-.a11yfy-top-level-menu ul.open {
+.a11yfy-top-level-menu li.open ul {
     /* On hover, display the next level's menu */
     display: inline;
 }

--- a/a11yfy/jquery.a11yfy.core.js
+++ b/a11yfy/jquery.a11yfy.core.js
@@ -204,8 +204,8 @@
                             $nextItem.attr("tabindex", "0").focus();
                             $this.attr("tabindex", "-1");
                             if ($nextItem.parent().get(0) !== $this.parent().get(0)) {
-                                $this.parent().removeClass("open").attr("aria-expanded", "false");
-                            }                            
+                                $this.parent().parent('li').removeClass("open").attr("aria-expanded", "false");
+                            }
                         }
                         e.stopPropagation();
                         e.preventDefault();
@@ -215,20 +215,18 @@
                          */
                         var keyCode = e.which || e.keyCode,
                             handled = false,
-                            $this = jQuery(this),
-                            $submenu;
+                            $this = jQuery(this);
 
                         if (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) {
                             // not interested
                             return;
                         }
-                        $submenu = $this.find(">ul").first();
                         /*
                          * Open a sub-menu and place focus on the first menuitem within it
                          */
                         function openMenu() {
-                            if ($submenu.length) {
-                                $submenu.addClass("open").attr("aria-expanded", "true").find(">li").first().attr("tabindex", "0").focus();
+                            if($this.hasClass("a11yfy-has-submenu")) {
+                                $this.addClass("open").attr("aria-expanded", "true").find(">ul>li").first().attr("tabindex", "0").focus();
                                 $this.attr("tabindex", "-1");
                             }
                         }
@@ -280,8 +278,8 @@
                                 } else {
                                     if ($this.parent().attr("role") === "menu") {
                                         // this is part of a submenu, set focus on containing li
-                                        $this.parent().parent().attr("tabindex", "0").focus();
-                                        $this.parent().removeClass("open").attr("aria-expanded", "false");
+                                        $this.parent().parent().attr("tabindex", "0").focus()
+                                            .removeClass("open").attr("aria-expanded", "false");
                                         $this.attr("tabindex", "-1");
                                     }
                                 }
@@ -322,12 +320,12 @@
                             e.stopPropagation();
                         }
                     }).on("click", function() {
-                        var $submenu = jQuery(this).find(">ul").first();
+                        var $this = jQuery(this);
 
-                        if ($submenu.is(":hidden")) {
-                            $submenu.addClass("open").attr("aria-expanded", "true");
+                        if ($this.is(":hidden")) {
+                            $this.addClass("open").attr("aria-expanded", "true");
                         } else {
-                            $submenu.removeClass("open").attr("aria-expanded", "false");
+                            $this.removeClass("open").attr("aria-expanded", "false");
                         }
                     }).first().attr("tabindex", "0"); // Make the first menuitem in the menubar tab focussable
                     $this.on("keydown", function (e) {
@@ -356,9 +354,9 @@
                              * menubar so it receives focus when the user tabs back into the menubar
                              */
                             $this.find(">li li[tabindex=0]").attr("tabindex", "-1");
-                            $this.find("ul.open").each(function(index, value) {
-                                if (jQuery(value).parent().parent().hasClass("a11yfy-top-level-menu")) {
-                                    jQuery(value).parent().attr("tabindex", "0");
+                            $this.find("li.open").each(function(index, value) {
+                                if (jQuery(value).parent().hasClass("a11yfy-top-level-menu")) {
+                                    jQuery(value).attr("tabindex", "0");
                                 }
                             }).removeClass("open").attr("aria-expanded", "false");
                         }

--- a/tests/unit/a11yfy/a11yfy.js
+++ b/tests/unit/a11yfy/a11yfy.js
@@ -147,7 +147,7 @@
         equal(jQuery(document.activeElement).attr("id"), "test2-6", "Should b in sub-menu");
         jQuery(document.activeElement).simulate("keypress", {charCode: 70}); // "f"
         equal(jQuery(document.activeElement).attr("id"), "test2-15", "f should go to the last item in the top menu");
-        equal(jQuery("#test2-6").parent().attr("aria-expanded"), "false", "sub-menu state should be set to not expanded");
+        equal(jQuery("#test2-6").parent().parent().attr("aria-expanded"), "false", "sub-menu state should be set to not expanded");
         equal(jQuery("#test2-6:visible").length, 0, "sub-menu should no longer be visible");
         jQuery(document.activeElement).simulate("keydown", {keyCode: 39}); // RIGHT
         equal(jQuery(document.activeElement).attr("id"), "test2-0", "Right goes back to the beginning");
@@ -158,8 +158,8 @@
         equal(jQuery(document.activeElement).attr("id"), "test2-5", "Right should get us to the second top level menu item");
         jQuery(document.activeElement).simulate("keydown", {keyCode: 40}); // DOWN
         equal(jQuery(document.activeElement).attr("id"), "test2-6", "Down on the second top level menu item (with a sub menu) should open it and set focus into it");
-        equal(jQuery(document.activeElement).parent().attr("aria-expanded"), "true", "When opened, the menu should have aria-expanded set to true");
-        ok(jQuery(document.activeElement).parent().hasClass("open"), "When opened, the menu should have open class");
+        equal(jQuery(document.activeElement).parent().parent().attr("aria-expanded"), "true", "When opened, the menu should have aria-expanded set to true");
+        ok(jQuery(document.activeElement).parent().parent().hasClass("open"), "When opened, the menu should have open class");
         jQuery(document.activeElement).simulate("keydown", {keyCode: 27}); // ESC
         equal(jQuery(document.activeElement).attr("id"), "test2-5", "ESC should close the sub-menu");
         jQuery(document.activeElement).simulate("keydown", {keyCode: 38}); // UP
@@ -184,8 +184,8 @@
         // Close sub-sub-menu
         jQuery(document.activeElement).simulate("keydown", {keyCode: 27}); // ESC
         equal(jQuery(document.activeElement).attr("id"), "test2-6", "ESC should close the sub-sub-menu");
-        equal(jQuery("#test2-7").parent().attr("aria-expanded"), "false", "aria-expended should be false after close");
-        ok(!jQuery("#test2-7").parent().hasClass("open"), "open class should be removed after close");
+        equal(jQuery("#test2-7").parent().parent().attr("aria-expanded"), "false", "aria-expended should be false after close");
+        ok(!jQuery("#test2-7").parent().parent().hasClass("open"), "open class should be removed after close");
         // Open sub-sub-menu
         jQuery(document.activeElement).simulate("keydown", {keyCode: 39}); // RIGHT
         equal(jQuery(document.activeElement).attr("id"), "test2-7", "open the sub-sub-menu");
@@ -198,7 +198,7 @@
 
         $menu.simulate("keydown", {keyCode: 9}); // TAB
         equal(jQuery("#test2-6").attr("tabindex"), "-1", "Tab should cause the sub-menus to all be closed and the tabindexes set to -1");
-        equal(jQuery("#test2-6").parent().attr("aria-expanded"), "false", "sub-menu state should be set to not expanded");
+        equal(jQuery("#test2-6").parent().parent().attr("aria-expanded"), "false", "sub-menu state should be set to not expanded");
         equal(jQuery("#test2-6:visible").length, 0, "sub-menu should no longer be visible");
         // focus should now go to the parent of the sub-menu previously focussed
         $menu.find("li[tabindex=0]").simulate("focus");


### PR DESCRIPTION
- Set open class on containing list item, this allows for greater flexibility in styling
- Set aria-expanded on the list item who owns the expanded menu
- Initially set aria-expanded, per spec aria-expanded should be undefined when; "The element, or another grouping element it controls, is neither expandable nor collapsible; all its child elements are shown or there are no child elements."
